### PR TITLE
Added option to disable runtime exceptions

### DIFF
--- a/lib/jmespath.rb
+++ b/lib/jmespath.rb
@@ -23,14 +23,14 @@ module JMESPath
     # @param [Hash] data
     # @return [Mixed,nil] Returns the matched values. Returns `nil` if the
     #   expression does not resolve inside `data`.
-    def search(expression, data)
+    def search(expression, data, runtime_options = {})
       data = case data
         when Hash, Struct then data # check for most common case first
         when Pathname then load_json(data)
         when IO, StringIO then JSON.load(data.read)
         else data
         end
-      Runtime.new.search(expression, data)
+      Runtime.new(runtime_options).search(expression, data)
     end
 
     # @api private

--- a/lib/jmespath/nodes/slice.rb
+++ b/lib/jmespath/nodes/slice.rb
@@ -6,6 +6,7 @@ module JMESPath
         @start = start
         @stop = stop
         @step = step
+        raise Errors::InvalidValueError.new('slice step cannot be 0') if @step == 0
       end
 
       def visit(value)
@@ -44,8 +45,6 @@ module JMESPath
       def adjust_slice(length, start, stop, step)
         if step.nil?
           step = 1
-        elsif step == 0
-          raise Errors::InvalidValueError, 'slice step cannot be 0'
         end
 
         if start.nil?

--- a/lib/jmespath/parser.rb
+++ b/lib/jmespath/parser.rb
@@ -29,6 +29,7 @@ module JMESPath
     # @option options [Lexer] :lexer
     def initialize(options = {})
       @lexer = options[:lexer] || Lexer.new
+      @disable_visit_errors = options[:disable_visit_errors]
     end
 
     # @param [String<JMESPath>] expression
@@ -198,7 +199,7 @@ module JMESPath
         end
       end
       stream.next
-      Nodes::Function.create(name, args)
+      Nodes::Function.create(name, args, :disable_visit_errors => @disable_visit_errors)
     end
 
     def led_or(stream, left)

--- a/lib/jmespath/runtime.rb
+++ b/lib/jmespath/runtime.rb
@@ -3,7 +3,7 @@ module JMESPath
   class Runtime
 
     # @api private
-    DEFAULT_PARSER = CachingParser.new
+    DEFAULT_PARSER = CachingParser
 
     # Constructs a new runtime object for evaluating JMESPath expressions.
     #
@@ -35,6 +35,11 @@ module JMESPath
     #   caching parser will be used. When `true`, a shared instance of
     #   {CachingParser} is used.  Defaults to `true`.
     #
+    # @option options [Boolean] :disable_visit_errors (false) When `true`,
+    #   no errors will be raised during runtime processing. Parse errors
+    #   will still be raised, but unexpected data sent to visit will
+    #   result in nil being returned.
+    #
     # @option options [Parser,CachingParser] :parser
     #
     def initialize(options = {})
@@ -58,7 +63,7 @@ module JMESPath
       if options[:cache_expressions] == false
         Parser.new(options)
       else
-        DEFAULT_PARSER
+        DEFAULT_PARSER.new(options)
       end
     end
 

--- a/spec/compliance_without_errors_spec.rb
+++ b/spec/compliance_without_errors_spec.rb
@@ -32,7 +32,7 @@ describe 'Compliance' do
 
                   raised = nil
                   begin
-                    PARSER.parse(test_case['expression']).visit(scenario['given'])
+                    PARSER.parse(test_case['expression'])
                   rescue JMESPath::Errors::Error => error
                     raised = error
                   end

--- a/spec/compliance_without_errors_spec.rb
+++ b/spec/compliance_without_errors_spec.rb
@@ -1,0 +1,49 @@
+require 'simplecov'
+require 'jmespath'
+require 'rspec'
+
+SimpleCov.command_name('test:compliance')
+
+describe 'Compliance' do
+  PARSER = JMESPath::Parser.new(:disable_visit_errors => true)
+  Dir.glob('spec/compliance/*.json').each do |path|
+    describe(File.basename(path).split('.').first) do
+      JMESPath.load_json(path).each do |scenario|
+        describe("Given #{scenario['given'].inspect}") do
+          scenario['cases'].each do |test_case|
+
+            if test_case['error']
+
+              if %w[invalid-type invalid-arity].include?(test_case['error'])
+                it "the expression #{test_case['expression'].inspect} returns nil if disable_visit_errors is true" do
+
+                  result = PARSER.parse(test_case['expression']).visit(scenario['given'])
+                  expect(result).to be_nil
+                end
+              else
+                it "the expression #{test_case['expression'].inspect} raises a #{test_case['error']} error when parsing even if disable_visit_errors is true" do
+
+                  error_class = case test_case['error']
+                    when 'syntax' then JMESPath::Errors::SyntaxError
+                    when 'invalid-value' then JMESPath::Errors::InvalidValueError
+                    when 'unknown-function' then JMESPath::Errors::UnknownFunctionError
+                    else raise "unhandled error type #{test_case['error']}"
+                  end
+
+                  raised = nil
+                  begin
+                    PARSER.parse(test_case['expression']).visit(scenario['given'])
+                  rescue JMESPath::Errors::Error => error
+                    raised = error
+                  end
+
+                  expect(raised).to be_kind_of(error_class)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the option `disable_visit_errors`, which disables the raising of errors during runtime. Parse errors will still be raised, but all exceptions during `Node.visit(object)` are disabled and `nil` is returned instead. 

We process very large amounts of data and sometimes objects do not have quite the right properties. So we have to catch `InvalidArityError` and `InvalidTypeError` since there is no way to preemptively check for these errors. This has quite a large overhead, especially in JRuby.

I did some benchmarks with objects that always result in an exception, and this branch had a 40% speed increase in MRI, and a 500% increase in JRuby. 
When not raising errors, there's no measurable difference between this branch and master, and also no difference between `disable_visit_errors` being off or on.