### PR TITLE
Replaced json dependency with json_pure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Unreleased Changes
+------------------
+
+* Removed hard dependency on `json >= 1.8.1`. Replaced with `json_pure >= 1.8.1`.
+  The runtime will still attempt to load the faster gem, if availble and will fall
+  back on `json_pure` for compatability. Ruby 2.0+ ships with 1.8.1 by default,
+  so only Ruby 1.9.3 will default to the slower version.
+
+  [See related GitHub issue #18](https://github.com/jmespath/jmespath.rb/pull/18).
+
 1.2.1 (2016-03-31)
 ------------------
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake', require: false
-gem 'json', '>= 1.8.1'
+gem 'json_pure', '>= 1.8.1'
 
 group :test do
   gem 'rspec', '~> 3.0'

--- a/jmespath.gemspec
+++ b/jmespath.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache 2.0'
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb'] + ['LICENSE.txt']
-  spec.add_runtime_dependency 'json', '>= 1.8.1'
+  spec.add_runtime_dependency 'json_pure', '>= 1.8.1'
 end

--- a/lib/jmespath.rb
+++ b/lib/jmespath.rb
@@ -1,6 +1,14 @@
-gem('json', '>= 1.8.1') # fix for Ruby 1.9.3
+begin
+  # Attempt to load the native version if available, not availble
+  # by default for Ruby 1.9.3.
+  gem('json', '>= 1.8.1')
+  require 'json/ext'
+rescue Gem::LoadError
+  # Fallback on the json_pure gem dependency.
+  gem('json_pure', '>= 1.8.1')
+  require 'json/pure'
+end
 
-require 'json'
 require 'stringio'
 require 'pathname'
 


### PR DESCRIPTION
Removed hard dependency on `json >= 1.8.1`. Replaced with `json_pure >= 1.8.1`. The runtime will still attempt to load the faster gem, if availble and will fall back on `json_pure` for compatability. Ruby 2.0+ ships with 1.8.1 by default, so only Ruby 1.9.3 will default to the slower version.

See #18