### PR TITLE
Allow the JSON library to load available variant

### DIFF
--- a/lib/jmespath.rb
+++ b/lib/jmespath.rb
@@ -5,11 +5,11 @@ else
     # Attempt to load the native version if available, not availble
     # by default for Ruby 1.9.3.
     gem('json', '>= 1.8.1')
-    require 'json/ext'
+    require 'json'
   rescue Gem::LoadError
     # Fallback on the json_pure gem dependency.
     gem('json_pure', '>= 1.8.1')
-    require 'json/pure'
+    require 'json'
   end
 end
 


### PR DESCRIPTION
Hi! I'm having some downstream issues due to the way the JSON library is getting
loaded in your code (sparkleformation/sfn#178). Due to other libraries also loading
JSON and the ext variant being available, both variants end up being loaded. As a result
TypeErrors are encountered:

* https://github.com/jmespath/jmespath.rb/pull/19#issuecomment-204187489

I tracked down an issue in the JSON repository (flori/json#269) that describes the
issue and from local testing it appears the underlying problem is a conflict between
the two implementations where each provides a subset of the entire functionality. The
result ends up being failures to generate JSON output depending on the data types. The
`Fixnum` type is an easy one to see fail.

From the documentation of the json project site (https://github.com/flori/json):

> JSON first tries to load the extension variant. If this fails, the pure variant is loaded and used.

This is a bit more explanatory than the README file. Since the library will automatically
fallback to the pure variant if available, using `require 'json'` in both places is perfectly
acceptable to get the desired results. The loading bit can be seen here:

https://github.com/flori/json/blob/master/lib/json.rb#L57-L62

This would fix the issue for a number of downstream libraries and applications and
would be much appreciated to get merged and released when you can.

Thanks!