### PR TITLE
Simplify and optimize Util.falsey?

### DIFF
--- a/lib/jmespath/util.rb
+++ b/lib/jmespath/util.rb
@@ -8,15 +8,11 @@ module JMESPath
       #   https://github.com/jmespath/jmespath.site/blob/master/docs/proposals/improved-filters.rst#and-expressions-1
       #
       def falsey?(value)
-        value.nil? ||
-        value === false ||
-        value == '' ||
-        value == {} ||
-        value == [] ||
-        (value.respond_to?(:entries) && value.entries.compact.empty?)
+        !value ||
+        (value.respond_to?(:empty?) && value.empty?) ||
+        (value.respond_to?(:entries) && !value.entries.any?)
         # final case necessary to support Enumerable and Struct
       end
-
     end
   end
 end


### PR DESCRIPTION
I noticed that there was a new utility function that encapsulated the JMESPath rules for false. It's great that an important definition like that is not repeated over and over again.

However, I think the implementation for an often used function like this needs to take performance into account. Using literals in Ruby is problematic since they're allocated on each call, leading to unnecessary garbage being created.

I rewrote the code to avoid allocations, and also simplified it slightly.

These are benchmarks for a few different inputs before these changes (the full benchmark code is below).

```
                                     user     system      total        real
true                             0.450000   0.010000   0.460000 (  0.458666)
false                            0.120000   0.000000   0.120000 (  0.118656)
{}                               0.440000   0.000000   0.440000 (  0.437886)
[]                               0.730000   0.000000   0.730000 (  0.739866)
["a"]                            0.960000   0.000000   0.960000 (  0.968578)
{"a"=>"b"}                       1.080000   0.000000   1.080000 (  1.085161)
#<Object:0x007fe6c4088c90>       0.460000   0.010000   0.470000 (  0.462774)
nil                              0.090000   0.000000   0.090000 (  0.095598)
#<struct Foo one=nil, two=nil>   0.850000   0.000000   0.850000 (  0.848883)
#<struct Foo one=1, two=2>       0.860000   0.000000   0.860000 (  0.866559)
```

And these are the numbers with the changes applied:

```
                                     user     system      total        real
true                             0.340000   0.000000   0.340000 (  0.341450)
false                            0.090000   0.000000   0.090000 (  0.088636)
{}                               0.160000   0.000000   0.160000 (  0.159498)
[]                               0.170000   0.000000   0.170000 (  0.166334)
["a"]                            0.470000   0.000000   0.470000 (  0.479173)
{"a"=>"b"}                       0.630000   0.000000   0.630000 (  0.637846)
#<Object:0x007fddd204bdb8>       0.360000   0.010000   0.370000 (  0.367299)
nil                              0.090000   0.000000   0.090000 (  0.093467)
#<struct Foo one=nil, two=nil>   0.540000   0.000000   0.540000 (  0.543378)
#<struct Foo one=1, two=2>       0.530000   0.000000   0.530000 (  0.536465)
```

Notice especially the difference for the non-empty array hash cases. Checking that a hash is empty is much better than checking whether or not it is equal to another hash.

The benchmarks of course don't capture the most important aspect of this, GC pressure.

This is the full benchmark code:

```ruby
Foo = Struct.new(:one, :two)

Benchmark.bmbm do |x|
  [
    true,
    false,
    {},
    [],
    ['a'],
    {'a' => 'b'},
    Object.new,
    nil,
    Foo.new,
    Foo.new(1, 2),
  ].each do |thing|
    x.report(thing.inspect) { 1_000_000.times { JMESPath::Util.falsey?(thing) } }
  end
end
```

We're have systems that are doing thousands, of not tens of thousands of JMESPath searches per second, so every little bit of performance counts.