### PR TITLE
Improved error handling

### DIFF
--- a/lib/jmespath/parser.rb
+++ b/lib/jmespath/parser.rb
@@ -46,7 +46,7 @@ module JMESPath
 
     # @api private
     def method_missing(method_name, *args)
-      if matches = method_name.match(/^(nud_|led_)(.*)/)
+      if matches = method_name.to_s.match(/^(nud_|led_)(.*)/)
         raise Errors::SyntaxError, "unexpected token #{matches[2]}"
       else
         super
@@ -153,6 +153,10 @@ module JMESPath
 
     def nud_star(stream)
       parse_wildcard_object(stream, CURRENT_NODE)
+    end
+
+    def nud_unknown(stream)
+      raise Errors::SyntaxError, "unknown token #{stream.token.value.inspect}"
     end
 
     def led_comparator(stream, left)


### PR DESCRIPTION
Consider the following expression:
```
`foo`
```
This expression contains an invalid json-value, and this will raise the unhelpful error `unexpected token 0`. The reason for the zero is that `Symbol#match` surprisingly returns a fixnum, unlike `String#match`. Still, `unexpected token unknown` would not be much better, therefore unknown tokens raise a separate error, in this case `unknown token "foo"`.

(Note that this particular expression is accepted by other implementations, but I don't think it should be according to the specification.)