### PR TITLE
Native JRuby implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@
 /docs.zip
 /.yardoc
 /jmespath-*.gem
+/.bundle
+/.mvn
+/.ruby-version
+/vendor
+/ext/target
+/lib/jmespath/ext
+/tmp
+/pkg
+/coverage

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,5 @@
+--color
+--format doc
+-Ilib
+-rspec_helper
+spec

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
+--tty
 --color
 --format doc
 -Ilib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
+language: ruby
+
 script: bundle exec rake
 
 bundler_args: --without docs release benchmark
 
 rvm:
-- 1.9.3
-- 2.0.0
-- 2.1
-- 2.2
-- 2.3.1
-- jruby
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2
+  - 2.3.1
+  - jruby-19mode
+  - jruby-9.1.2.0
 
 gemfile:
   - gemfiles/no-deps.gemfile
@@ -21,6 +24,11 @@ matrix:
     # latest version of `json` gem, 2.0+, is not supported on Ruby 1.9.3
     - rvm: 1.9.3
       gemfile: gemfiles/json-latest.gemfile
+
+cache:
+  bundler: true
+  directories:
+    - $HOME/.m2
 
 notifications:
   webhooks:

--- a/.yardopts
+++ b/.yardopts
@@ -1,6 +1,8 @@
 --title 'jmespath.rb'
+--no-private
 --output-dir docs
 --markup markdown
 --markup-provider rdiscount
 --hide-api private
 --plugin sitemap
+-- README.md

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rake', require: false
-gem 'rspec', '~> 3.0'
+gemspec
 
 group :docs do
   gem 'yard'
@@ -15,4 +14,9 @@ end
 
 group :benchmark do
   gem 'absolute_time'
+end
+
+group :test do
+  gem 'rake', require: false
+  gem 'rspec', '~> 3.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ $: << File.join($GEM_ROOT, 'lib')
 $VERSION = ENV['VERSION'] || File.read(File.join($GEM_ROOT, 'VERSION'))
 $GITHUB_ACCESS_TOKEN = ENV['JMESPATH_GITHUB_ACCESS_TOKEN']
 
-Dir.glob('**/*.rake').each do |task_file|
+Dir.glob('tasks/*.rake').each do |task_file|
   load task_file
 end
 

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.burt</groupId>
+  <artifactId>jmespath-jruby</artifactId>
+  <version>0.1.0</version>
+  <name>JMESPath JRuby</name>
+  <description>A JMESPath implementation for JRuby</description>
+
+  <properties>
+    <jmespath.version>0.1.0</jmespath.version>
+    <jruby.version>1.7.25</jruby.version>
+    <junit.version>4.12</junit.version>
+    <hamcrest.version>1.3</hamcrest.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.burt</groupId>
+      <artifactId>jmespath-core</artifactId>
+      <version>${jmespath.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.burt</groupId>
+      <artifactId>jmespath-core</artifactId>
+      <version>${jmespath.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>${jruby.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -10,7 +10,7 @@
   <description>A JMESPath implementation for JRuby</description>
 
   <properties>
-    <jmespath.version>0.1.0</jmespath.version>
+    <jmespath.version>0.1.1-SNAPSHOT</jmespath.version>
     <jruby.version>1.7.25</jruby.version>
     <junit.version>4.12</junit.version>
     <hamcrest.version>1.3</hamcrest.version>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -53,6 +53,19 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:deprecation</arg>
+            <arg>-Xlint:unchecked</arg>
+          </compilerArgs>
+          <source>7</source>
+          <target>7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.6</version>
         <configuration>

--- a/ext/src/main/java/io/burt/jmespath/jruby/JRubyRuntime.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JRubyRuntime.java
@@ -204,47 +204,17 @@ public class JRubyRuntime extends BaseRuntime<IRubyObject> {
           return value1.isTrue() == value2.isTrue() ? 0 : -1;
         case NUMBER:
         case STRING:
+        case ARRAY:
           RubyObject o1 = (RubyObject) value1;
           RubyObject o2 = (RubyObject) value2;
           return o1.compareTo(o2);
-        case ARRAY:
-          return deepEqualsArray(value1, value2) ? 0 : -1;
         case OBJECT:
-          return deepEqualsObject(value1, value2) ? 0 : -1;
+          return value1.op_equal(ruby.getCurrentContext(), value2).isTrue() ? 0 : -1;
         default:
           throw new IllegalStateException(String.format("Unknown node type encountered: %s", value1.getClass().getName()));
       }
     } else {
       return -1;
     }
-  }
-
-  private boolean deepEqualsArray(IRubyObject value1, IRubyObject value2) {
-    List<IRubyObject> values1 = toList(value1);
-    List<IRubyObject> values2 = toList(value2);
-    int size = values1.size();
-    if (size != values2.size()) {
-      return false;
-    }
-    for (int i = 0; i < size; i++) {
-      if (compare(values1.get(i), values2.get(i)) != 0) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private boolean deepEqualsObject(IRubyObject value1, IRubyObject value2) {
-    Collection<IRubyObject> keys1 = getPropertyNames(value1);
-    Collection<IRubyObject> keys2 = getPropertyNames(value2);
-    if (!keys1.containsAll(keys2) || !keys2.containsAll(keys1)) {
-      return false;
-    }
-    for (IRubyObject key : keys1) {
-      if (compare(getProperty(value1, key), getProperty(value2, key)) != 0) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/ext/src/main/java/io/burt/jmespath/jruby/JRubyRuntime.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JRubyRuntime.java
@@ -128,6 +128,7 @@ public class JRubyRuntime extends BaseRuntime<IRubyObject> {
   }
 
   @Override
+  @Deprecated
   public IRubyObject getProperty(IRubyObject value, String name) {
     return getProperty(value, ruby.newString(name));
   }

--- a/ext/src/main/java/io/burt/jmespath/jruby/JRubyRuntime.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JRubyRuntime.java
@@ -128,12 +128,6 @@ public class JRubyRuntime extends BaseRuntime<IRubyObject> {
   }
 
   @Override
-  @Deprecated
-  public IRubyObject getProperty(IRubyObject value, String name) {
-    return getProperty(value, ruby.newString(name));
-  }
-
-  @Override
   public IRubyObject getProperty(IRubyObject value, IRubyObject name) {
     int nativeTypeIndex = ((RubyObject) value).getNativeTypeIndex();
     if (nativeTypeIndex == ClassIndex.HASH) {

--- a/ext/src/main/java/io/burt/jmespath/jruby/JRubyRuntime.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JRubyRuntime.java
@@ -1,0 +1,174 @@
+package io.burt.jmespath.jruby;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.jruby.Ruby;
+import org.jruby.RubyModule;
+import org.jruby.RubyString;
+import org.jruby.RubyBoolean;
+import org.jruby.RubyNumeric;
+import org.jruby.RubyInteger;
+import org.jruby.RubyArray;
+import org.jruby.RubyHash;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import io.burt.jmespath.BaseRuntime;
+import io.burt.jmespath.JmesPathType;
+
+public class JRubyRuntime extends BaseRuntime<IRubyObject> {
+  private final Ruby ruby;
+
+  public JRubyRuntime(Ruby ruby) {
+    this.ruby = ruby;
+  }
+
+  private RubyModule json() {
+    ruby.getLoadService().require("json");
+    return ruby.getClassFromPath("JSON");
+  }
+
+  @Override
+  public IRubyObject parseString(String string) {
+    return json().callMethod(ruby.getCurrentContext(), "load", ruby.newString(string));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<IRubyObject> toList(IRubyObject value) {
+    if (value instanceof RubyArray) {
+      RubyArray array = (RubyArray) value;
+      return (List<IRubyObject>) array.getList();
+    } else if (value instanceof RubyHash) {
+      RubyHash hash = (RubyHash) value;
+      return (List<IRubyObject>) hash.rb_values().getList();
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  @Override
+  public String toString(IRubyObject value) {
+    if (value instanceof RubyString) {
+      return value.asJavaString();
+    } else {
+      return json().callMethod(ruby.getCurrentContext(), "dump", value).toString();
+    }
+  }
+
+  @Override
+  public Number toNumber(IRubyObject value) {
+    if (value instanceof RubyInteger) {
+      return ((RubyInteger) value).getLongValue();
+    } else if (value instanceof RubyNumeric) {
+      return ((RubyNumeric) value).getDoubleValue();
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public JmesPathType typeOf(IRubyObject value) {
+    if (value != null && value.isNil()) {
+      return JmesPathType.NULL;
+    } else if (value instanceof RubyString) {
+      return JmesPathType.STRING;
+    } else if (value instanceof RubyNumeric) {
+      return JmesPathType.NUMBER;
+    } else if (value instanceof RubyBoolean) {
+      return JmesPathType.BOOLEAN;
+    } else if (value instanceof RubyArray) {
+      return JmesPathType.ARRAY;
+    } else if (value instanceof RubyHash) {
+      return JmesPathType.OBJECT;
+    } else {
+      throw new IllegalStateException(String.format("Unknown node type encountered: %s", value.getClass().getName()));
+    }
+  }
+
+  @Override
+  public boolean isTruthy(IRubyObject value) {
+    switch (typeOf(value)) {
+      case NULL:
+        return false;
+      case NUMBER:
+        return true;
+      case BOOLEAN:
+        return value.isTrue();
+      case ARRAY:
+        return !((RubyArray) value).isEmpty();
+      case OBJECT:
+        return !((RubyHash) value).isEmpty();
+      case STRING:
+        return !((RubyString) value).isEmpty();
+      default:
+        throw new IllegalStateException(String.format("Unknown node type encountered: %s", value.getClass().getName()));
+    }
+  }
+
+  @Override
+  public IRubyObject getProperty(IRubyObject value, String name) {
+    return getProperty(value, ruby.newString(name));
+  }
+
+  @Override
+  public IRubyObject getProperty(IRubyObject value, IRubyObject name) {
+    if (value instanceof RubyHash) {
+      IRubyObject result = ((RubyHash) value).fastARef(name);
+      return result == null ? ruby.getNil() : result;
+    } else {
+      return ruby.getNil();
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Collection<IRubyObject> getPropertyNames(IRubyObject value) {
+    if (value instanceof RubyHash) {
+      RubyHash hash = (RubyHash) value;
+      return (Collection<IRubyObject>) hash.keys().getList();
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  @Override
+  public IRubyObject createNull() {
+    return ruby.getNil();
+  }
+
+  private static final IRubyObject[] RUBY_OBJECT_ARRAY_TYPE = new IRubyObject[] {};
+
+  @Override
+  public IRubyObject createArray(Collection<IRubyObject> elements) {
+    return ruby.newArray(elements.toArray(RUBY_OBJECT_ARRAY_TYPE));
+  }
+
+  @Override
+  public IRubyObject createString(String str) {
+    return ruby.newString(str);
+  }
+
+  @Override
+  public IRubyObject createBoolean(boolean b) {
+    return b ? ruby.getTrue() : ruby.getFalse();
+  }
+
+  @Override
+  public IRubyObject createObject(Map<IRubyObject, IRubyObject> obj) {
+    return RubyHash.newHash(ruby, obj, ruby.getNil());
+  }
+
+  @Override
+  public IRubyObject createNumber(double n) {
+    return ruby.newFloat(n);
+  }
+
+  @Override
+  public IRubyObject createNumber(long n) {
+    return ruby.newFixnum(n);
+  }
+}

--- a/ext/src/main/java/io/burt/jmespath/jruby/JmesPath.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JmesPath.java
@@ -10,14 +10,17 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.ObjectAllocator;
 
 import io.burt.jmespath.Expression;
+import io.burt.jmespath.parser.ParseException;
 
 @JRubyClass(name = "JMESPath")
 public class JmesPath extends RubyObject {
   private final JRubyRuntime jmespath;
+  private final RubyClass parseErrorClass;
 
   public JmesPath(Ruby ruby, RubyClass type) {
     super(ruby, type);
     this.jmespath = new JRubyRuntime(ruby);
+    this.parseErrorClass = (RubyClass) ruby.getClassFromPath("JMESPath::ParseError");
   }
 
   private static class JmesPathAllocator implements ObjectAllocator {
@@ -26,13 +29,18 @@ public class JmesPath extends RubyObject {
     }
   }
 
-  static void install(Ruby ruby) {
+  static RubyClass install(Ruby ruby) {
     RubyClass jmesPathClass = ruby.defineClass("JMESPath", ruby.getObject(), new JmesPathAllocator());
     jmesPathClass.defineAnnotatedMethods(JmesPath.class);
+    return jmesPathClass;
   }
 
   @JRubyMethod
   public IRubyObject compile(ThreadContext ctx, IRubyObject expression) {
-    return JmesPathExpression.create(ctx.runtime, jmespath.compile(expression.toString()));
+    try {
+      return JmesPathExpression.create(ctx.runtime, jmespath.compile(expression.toString()));
+    } catch (ParseException pe) {
+      throw ctx.runtime.newRaiseException(parseErrorClass, pe.getMessage());
+    }
   }
 }

--- a/ext/src/main/java/io/burt/jmespath/jruby/JmesPath.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JmesPath.java
@@ -1,0 +1,38 @@
+package io.burt.jmespath.jruby;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.ObjectAllocator;
+
+import io.burt.jmespath.Expression;
+
+@JRubyClass(name = "JMESPath")
+public class JmesPath extends RubyObject {
+  private final JRubyRuntime jmespath;
+
+  public JmesPath(Ruby ruby, RubyClass type) {
+    super(ruby, type);
+    this.jmespath = new JRubyRuntime(ruby);
+  }
+
+  private static class JmesPathAllocator implements ObjectAllocator {
+    public IRubyObject allocate(Ruby ruby, RubyClass type) {
+      return new JmesPath(ruby, type);
+    }
+  }
+
+  static void install(Ruby ruby) {
+    RubyClass jmesPathClass = ruby.defineClass("JMESPath", ruby.getObject(), new JmesPathAllocator());
+    jmesPathClass.defineAnnotatedMethods(JmesPath.class);
+  }
+
+  @JRubyMethod
+  public IRubyObject compile(ThreadContext ctx, IRubyObject expression) {
+    return JmesPathExpression.create(ctx.runtime, jmespath.compile(expression.toString()));
+  }
+}

--- a/ext/src/main/java/io/burt/jmespath/jruby/JmesPathExpression.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JmesPathExpression.java
@@ -2,6 +2,7 @@ package io.burt.jmespath.jruby;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.anno.JRubyClass;
@@ -10,19 +11,26 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.ObjectAllocator;
 
 import io.burt.jmespath.Expression;
+import io.burt.jmespath.function.ArityException;
+import io.burt.jmespath.function.ArgumentTypeException;
 
 @JRubyClass(name = "JMESPath::Expression")
 public class JmesPathExpression extends RubyObject {
   private final Expression<IRubyObject> expression;
+  private final RubyClass arityErrorClass;
+  private final RubyClass argumentTypeErrorClass;
 
   public JmesPathExpression(Ruby ruby, RubyClass type, Expression<IRubyObject> expression) {
     super(ruby, type);
     this.expression = expression;
+    this.arityErrorClass = (RubyClass) ruby.getClassFromPath("JMESPath::ArityError");
+    this.argumentTypeErrorClass = (RubyClass) ruby.getClassFromPath("JMESPath::ArgumentTypeError");
   }
 
-  static void install(Ruby ruby) {
-    RubyClass jmesPathExpressionClass = ruby.getClassFromPath("JMESPath").defineClassUnder("Expression", ruby.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
+  static RubyClass install(Ruby ruby, RubyModule parentModule) {
+    RubyClass jmesPathExpressionClass = parentModule.defineClassUnder("Expression", ruby.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
     jmesPathExpressionClass.defineAnnotatedMethods(JmesPathExpression.class);
+    return jmesPathExpressionClass;
   }
 
   static IRubyObject create(Ruby ruby, Expression<IRubyObject> expression) {
@@ -31,6 +39,12 @@ public class JmesPathExpression extends RubyObject {
 
   @JRubyMethod
   public IRubyObject search(ThreadContext ctx, IRubyObject target) {
-    return expression.search(target);
+    try {
+      return expression.search(target);
+    } catch (ArityException ae) {
+      throw ctx.runtime.newRaiseException(arityErrorClass, ae.getMessage());
+    } catch (ArgumentTypeException ate) {
+      throw ctx.runtime.newRaiseException(argumentTypeErrorClass, ate.getMessage());
+    }
   }
 }

--- a/ext/src/main/java/io/burt/jmespath/jruby/JmesPathExpression.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JmesPathExpression.java
@@ -1,0 +1,36 @@
+package io.burt.jmespath.jruby;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.ObjectAllocator;
+
+import io.burt.jmespath.Expression;
+
+@JRubyClass(name = "JMESPath::Expression")
+public class JmesPathExpression extends RubyObject {
+  private final Expression<IRubyObject> expression;
+
+  public JmesPathExpression(Ruby ruby, RubyClass type, Expression<IRubyObject> expression) {
+    super(ruby, type);
+    this.expression = expression;
+  }
+
+  static void install(Ruby ruby) {
+    RubyClass jmesPathExpressionClass = ruby.getClassFromPath("JMESPath").defineClassUnder("Expression", ruby.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
+    jmesPathExpressionClass.defineAnnotatedMethods(JmesPathExpression.class);
+  }
+
+  static IRubyObject create(Ruby ruby, Expression<IRubyObject> expression) {
+    return new JmesPathExpression(ruby, (RubyClass) ruby.getClassFromPath("JMESPath::Expression"), expression);
+  }
+
+  @JRubyMethod
+  public IRubyObject search(ThreadContext ctx, IRubyObject target) {
+    return expression.search(target);
+  }
+}

--- a/ext/src/main/java/io/burt/jmespath/jruby/JmesPathLibrary.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JmesPathLibrary.java
@@ -19,7 +19,17 @@ import org.jruby.internal.runtime.methods.DynamicMethod;
 
 public class JmesPathLibrary implements Library {
   public void load(Ruby ruby, boolean wrap) {
-    JmesPath.install(ruby);
-    JmesPathExpression.install(ruby);
+    RubyClass jmesPathClass = JmesPath.install(ruby);
+    JmesPathExpression.install(ruby, jmesPathClass);
+    installErrors(ruby, jmesPathClass);
+  }
+
+  private void installErrors(Ruby ruby, RubyModule parentModule) {
+    RubyClass standardErrorClass = ruby.getStandardError();
+    RubyClass jmesPathError = parentModule.defineClassUnder("JMESPathError", standardErrorClass, standardErrorClass.getAllocator());
+    parentModule.defineClassUnder("ParseError", jmesPathError, jmesPathError.getAllocator());
+    RubyClass functionCallError = parentModule.defineClassUnder("FunctionCallError", jmesPathError, jmesPathError.getAllocator());
+    parentModule.defineClassUnder("ArityError", functionCallError, functionCallError.getAllocator());
+    parentModule.defineClassUnder("ArgumentTypeError", functionCallError, functionCallError.getAllocator());
   }
 }

--- a/ext/src/main/java/io/burt/jmespath/jruby/JmesPathLibrary.java
+++ b/ext/src/main/java/io/burt/jmespath/jruby/JmesPathLibrary.java
@@ -1,0 +1,25 @@
+package io.burt.jmespath.jruby;
+
+import org.jruby.Ruby;
+import org.jruby.RubyModule;
+import org.jruby.RubyClass;
+import org.jruby.RubyString;
+import org.jruby.RubyNil;
+import org.jruby.RubyBoolean;
+import org.jruby.RubyHash;
+import org.jruby.runtime.load.Library;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.Visibility;
+import org.jruby.anno.JRubyModule;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.internal.runtime.methods.CallConfiguration;
+import org.jruby.internal.runtime.methods.DynamicMethod;
+
+public class JmesPathLibrary implements Library {
+  public void load(Ruby ruby, boolean wrap) {
+    JmesPath.install(ruby);
+    JmesPathExpression.install(ruby);
+  }
+}

--- a/ext/src/test/java/io/burt/jmespath/jruby/JRubyComplianceTest.java
+++ b/ext/src/test/java/io/burt/jmespath/jruby/JRubyComplianceTest.java
@@ -1,0 +1,15 @@
+package io.burt.jmespath.jruby;
+
+import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import io.burt.jmespath.JmesPathComplianceTest;
+import io.burt.jmespath.Adapter;
+
+public class JRubyComplianceTest extends JmesPathComplianceTest<IRubyObject> {
+  private static final Ruby ruby = Ruby.newInstance();
+  private final Adapter<IRubyObject> runtime = new JRubyRuntime(ruby);
+
+  @Override
+  protected Adapter<IRubyObject> runtime() { return runtime; }
+}

--- a/ext/src/test/java/io/burt/jmespath/jruby/JRubyTest.java
+++ b/ext/src/test/java/io/burt/jmespath/jruby/JRubyTest.java
@@ -1,0 +1,33 @@
+package io.burt.jmespath.jruby;
+
+import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import io.burt.jmespath.JmesPathRuntimeTest;
+import io.burt.jmespath.Adapter;
+
+public class JRubyTest extends JmesPathRuntimeTest<IRubyObject> {
+  private static final Ruby ruby = Ruby.newInstance();
+  private final Adapter<IRubyObject> runtime = new JRubyRuntime(ruby);
+
+  @Override
+  protected Adapter<IRubyObject> runtime() { return runtime; }
+
+  @Override
+  protected IRubyObject parse(String json) {
+    try {
+      return super.parse(json);
+    } catch (RuntimeException e) {
+      if (e.getMessage().contains("unexpected token at '}'") && json.endsWith("}")) {
+        // NOTE This is a workaround for a mistake in the jmespath-java tests
+        //      one of the tests contains JSON with a trailing } that the other
+        //      implementations' JSON parsers don't care about.
+        //      When jmespath-core:0.1.1 is released this whole method can
+        //      be removed.
+        return super.parse(json.substring(0, json.length() - 1));
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/jmespath.gemspec
+++ b/jmespath.gemspec
@@ -1,12 +1,13 @@
 Gem::Specification.new do |spec|
   spec.name          = 'jmespath'
   spec.version       = File.read(File.expand_path('../VERSION', __FILE__)).strip
+  spec.platform      = (defined? JRUBY_VERSION) ? 'java' : Gem::Platform::RUBY
   spec.summary       = 'JMESPath - Ruby Edition'
   spec.description   = 'Implements JMESPath for Ruby'
-  spec.author        = 'Trevor Rowe'
+  spec.author        = ['Trevor Rowe', 'Theo Hultberg']
   spec.email         = 'trevorrowe@gmail.com'
-  spec.homepage      = 'http://github.com/trevorrowe/jmespath.rb'
+  spec.homepage      = 'http://github.com/jmespath/jmespath.rb'
   spec.license       = 'Apache 2.0'
   spec.require_paths = ['lib']
-  spec.files         = Dir['lib/**/*.rb'] + ['LICENSE.txt']
+  spec.files         = Dir['lib/**/*.rb', 'lib/**/*.jar', 'README.md', 'LICENSE.txt', 'VERSION']
 end

--- a/jmespath.gemspec
+++ b/jmespath.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/jmespath/jmespath.rb'
   spec.license       = 'Apache 2.0'
   spec.require_paths = ['lib']
-  spec.files         = Dir['lib/**/*.rb', 'lib/**/*.jar', 'README.md', 'LICENSE.txt', 'VERSION']
+  spec.files         = Dir['lib/**/*.rb', 'lib/**/*.jar', '.yardopts', 'README.md', 'LICENSE.txt', 'VERSION']
 end

--- a/lib/jmespath.rb
+++ b/lib/jmespath.rb
@@ -1,41 +1,47 @@
-require 'json'
-require 'stringio'
-require 'pathname'
+if defined? JRUBY_VERSION
+  require 'jmespath/ext/jmespath.jar'
 
-module JMESPath
+  Java::IoBurtJmespathJruby::JmesPathLibrary.new.load(JRuby.runtime, false)
+else
+  require 'json'
+  require 'stringio'
+  require 'pathname'
 
-  require 'jmespath/caching_parser'
-  require 'jmespath/errors'
-  require 'jmespath/lexer'
-  require 'jmespath/nodes'
-  require 'jmespath/parser'
-  require 'jmespath/runtime'
-  require 'jmespath/token'
-  require 'jmespath/token_stream'
-  require 'jmespath/util'
-  require 'jmespath/version'
+  module JMESPath
 
-  class << self
+    require 'jmespath/caching_parser'
+    require 'jmespath/errors'
+    require 'jmespath/lexer'
+    require 'jmespath/nodes'
+    require 'jmespath/parser'
+    require 'jmespath/runtime'
+    require 'jmespath/token'
+    require 'jmespath/token_stream'
+    require 'jmespath/util'
+    require 'jmespath/version'
 
-    # @param [String] expression A valid
-    #   [JMESPath](https://github.com/boto/jmespath) expression.
-    # @param [Hash] data
-    # @return [Mixed,nil] Returns the matched values. Returns `nil` if the
-    #   expression does not resolve inside `data`.
-    def search(expression, data, runtime_options = {})
-      data = case data
-        when Hash, Struct then data # check for most common case first
-        when Pathname then load_json(data)
-        when IO, StringIO then JSON.load(data.read)
-        else data
-        end
-      Runtime.new(runtime_options).search(expression, data)
+    class << self
+
+      # @param [String] expression A valid
+      #   [JMESPath](https://github.com/boto/jmespath) expression.
+      # @param [Hash] data
+      # @return [Mixed,nil] Returns the matched values. Returns `nil` if the
+      #   expression does not resolve inside `data`.
+      def search(expression, data, runtime_options = {})
+        data = case data
+          when Hash, Struct then data # check for most common case first
+          when Pathname then load_json(data)
+          when IO, StringIO then JSON.load(data.read)
+          else data
+          end
+        Runtime.new(runtime_options).search(expression, data)
+      end
+
+      # @api private
+      def load_json(path)
+        JSON.load(File.open(path, 'r', encoding: 'UTF-8') { |f| f.read })
+      end
+
     end
-
-    # @api private
-    def load_json(path)
-      JSON.load(File.open(path, 'r', encoding: 'UTF-8') { |f| f.read })
-    end
-
   end
 end

--- a/spec/jmespath_spec.rb
+++ b/spec/jmespath_spec.rb
@@ -1,38 +1,65 @@
 require 'spec_helper'
 
-module JMESPath
-  describe '.search' do
-
-    it 'searches data' do
-      expression = 'foo.bar'
-      data = {'foo' => {'bar' => 'value'}}
-      expect(JMESPath.search(expression, data)).to eq('value')
+if defined? JRUBY_VERSION
+  describe JMESPath do
+    let :jmespath do
+      described_class.new
     end
 
-    it 'accepts data as a Pathname' do
-      file_path = File.join(File.dirname(__FILE__), 'fixtures', 'sample.json')
-      file_path = Pathname.new(file_path)
-      expect(JMESPath.search('foo.*.baz', file_path)).to eq([1,2,3])
-    end
-
-    it 'accepts data as an IO object' do
-      file_path = File.join(File.dirname(__FILE__), 'fixtures', 'sample.json')
-      File.open(file_path, 'r') do |file|
-        expect(JMESPath.search('foo.*.baz', file)).to eq([1,2,3])
+    describe '#compile' do
+      it 'compiles an expression' do
+        expression = jmespath.compile('foo.bar')
+        expect(expression).to_not be_nil
       end
     end
+  end
 
-    it 'accepts data as an Struct' do
-      data = Struct.new(:foo).new(Struct.new(:bar).new('baz'))
-      expect(JMESPath.search('foo.bar', data)).to eq('baz')
+  describe JMESPath::Expression do
+    let :expression do
+      JMESPath.new.compile('foo.bar')
     end
 
-    it 'supports bare JSON literals' do
-      # this is problematic in older Ruby versions that ship with
-      # older versions of the json gem. This will only work
-      # with version 1.8.1+ of the json gem.
-      expect(JMESPath.search('`1` < `2`', {})).to be(true)
+    describe '#search' do
+      it 'searches the given input and returns the result' do
+        input = {'foo' => {'bar' => 42}}
+        expect(expression.search(input)).to eq(42)
+      end
     end
+  end
+else
+  module JMESPath
+    describe '.search' do
 
+      it 'searches data' do
+        expression = 'foo.bar'
+        data = {'foo' => {'bar' => 'value'}}
+        expect(JMESPath.search(expression, data)).to eq('value')
+      end
+
+      it 'accepts data as a Pathname' do
+        file_path = File.join(File.dirname(__FILE__), 'fixtures', 'sample.json')
+        file_path = Pathname.new(file_path)
+        expect(JMESPath.search('foo.*.baz', file_path)).to eq([1,2,3])
+      end
+
+      it 'accepts data as an IO object' do
+        file_path = File.join(File.dirname(__FILE__), 'fixtures', 'sample.json')
+        File.open(file_path, 'r') do |file|
+          expect(JMESPath.search('foo.*.baz', file)).to eq([1,2,3])
+        end
+      end
+
+      it 'accepts data as an Struct' do
+        data = Struct.new(:foo).new(Struct.new(:bar).new('baz'))
+        expect(JMESPath.search('foo.bar', data)).to eq('baz')
+      end
+
+      it 'supports bare JSON literals' do
+        # this is problematic in older Ruby versions that ship with
+        # older versions of the json gem. This will only work
+        # with version 1.8.1+ of the json gem.
+        expect(JMESPath.search('`1` < `2`', {})).to be(true)
+      end
+    end
   end
 end

--- a/spec/jmespath_spec.rb
+++ b/spec/jmespath_spec.rb
@@ -11,18 +11,63 @@ if defined? JRUBY_VERSION
         expression = jmespath.compile('foo.bar')
         expect(expression).to_not be_nil
       end
+
+      context 'when there is a syntax error' do
+        it 'raises an error' do
+          expect { jmespath.compile('%') }.to raise_error(JMESPath::ParseError)
+        end
+      end
+
+      context 'when the expression refers to a function that does not exist' do
+        it 'raises an error' do
+          expect { jmespath.compile('%') }.to raise_error(JMESPath::ParseError)
+        end
+      end
+
+      context 'when the expression uses an invalid value' do
+        it 'raises an error' do
+          expect { jmespath.compile('%') }.to raise_error(JMESPath::ParseError)
+        end
+      end
     end
   end
 
   describe JMESPath::Expression do
     let :expression do
-      JMESPath.new.compile('foo.bar')
+      JMESPath.new.compile(expression_str)
+    end
+
+    let :expression_str do
+      'foo.bar'
     end
 
     describe '#search' do
+      let :input do
+        {'foo' => {'bar' => 42}}
+      end
+
       it 'searches the given input and returns the result' do
-        input = {'foo' => {'bar' => 42}}
         expect(expression.search(input)).to eq(42)
+      end
+
+      context 'when a function is given the wrong number of arguments' do
+        let :expression_str do
+          'to_number(foo, bar)'
+        end
+
+        it 'raises an error' do
+          expect { expression.search(input) }.to raise_error(JMESPath::ArityError)
+        end
+      end
+
+      context 'when a function is given the wrong kind of argument' do
+        let :expression_str do
+          'max(@)'
+        end
+
+        it 'raises an error' do
+          expect { expression.search(input) }.to raise_error(JMESPath::ArgumentTypeError)
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
-# Using Bundler.require intentionally to simulate environments that have already
-# required a specific version of the `json` or `json_pure` gems. The actual version
-# loaded is decided by the specific gemfile being loaded from the gemfiles directory.
 require 'bundler'
+
 Bundler.require
 
 require 'jmespath'

--- a/tasks/jruby-extension.rake
+++ b/tasks/jruby-extension.rake
@@ -1,0 +1,18 @@
+if defined? JRUBY_VERSION
+  namespace :extension do
+    task :package do
+      Dir.chdir('ext') do
+        sh 'mvn package'
+      end
+    end
+
+    task :install => :package do
+      extension_jar = Dir['ext/target/jmespath-jruby-*-jar-with-dependencies.jar'].max
+      extension_dir = 'lib/jmespath/ext'
+      FileUtils.mkdir_p(extension_dir)
+      FileUtils.cp(extension_jar, File.join(extension_dir, 'jmespath.jar'))
+    end
+  end
+
+  task 'test:unit' => 'extension:install'
+end

--- a/tasks/jruby-extension.rake
+++ b/tasks/jruby-extension.rake
@@ -2,7 +2,7 @@ if defined? JRUBY_VERSION
   namespace :extension do
     task :package do
       Dir.chdir('ext') do
-        sh 'mvn package'
+        sh "mvn -Djruby.version=#{JRUBY_VERSION} package"
       end
     end
 


### PR DESCRIPTION
As mentioned in #37 my colleagues and I are working on both a Java and JRuby implementation of JMESPath. Ideally jmespath.rb should work the same in both, but that will require some work.

We could create a JRuby interface that mimicked the pure Ruby API as it is now, but a big part of the motivation for us to create a JRuby implementation is performance, and the current jmespath.rb API doesn't work very well for that. Therefore we propose a new API below, which could be released as jmespath.rb 2.0. It shouldn't be too far off from the current API, and depending on what you consider the public API of jmespath.rb to be it should be completely backwards compatible.

My proposal is that this would be the new public API:

``` ruby
require 'jmespath'

// main API

jmespath = JMESPath.new
expression = jmespath.compile('foo.bar')
result = expression.search({'foo' => {'bar' => 42}})

// backward compatibility API

result = JMESPath.search('foo.bar', {'foo' => {'bar' => 42}}) 
```

I would also like to make changes that are not backwards compatible:
- remove the support for passing `IO`, `Pathname`, etc. to `JMESPath.search`, i.e. make it accept only hashes/arrays/scalar values. Loading files, parsing JSON, etc. should not be the concern of this gem. There are a thousand ways to load a file and to parse JSON, let other gems worry about that.
- remove the feature that `JMESPath.search` caches parsed expressions. Besides having been broken for a long time, we don't feel it's a good idea to have a global cache. With the new API it's easy enough to cache the expressions yourself.
- remove `JMESPath::Parser`. It's clearly marked with `@private`, but it's the only way to get hold of parsed expressions or control caching yourself we assume that people are using it – just like we have done.
- remove `JMEPath::CachingParser`. It's not marked as private, but it should probably have been.
- remove `JMESPath::Runtime`. It's clearly marked with `@private`, but like with `JMESPath::Parser` we assume people have been using it anyway.

We will also change how the tests are run and bring in the compliance tests as a git submodule so that it's easier to stay up to date.

There are a few things that I'm not entirely sure what to do about:
- indifferent access – I think it should be an option, and not on by default. We want to make the default as fast as possible, and optimize for things loaded from JSON, which means string keys. I don't know if there should be an indifferent access mode, or separate modes where one could assume only symbol keys, one symbols or strings, etc.
- struct/object support – I don't think this is a good idea in general, but just like with indifferent access I can see it being supported and turned on with an option.
- the `:disable_visit_errors` option – this came from us, but I think it's not very thought through. Instead of disabling all errors whatever the cause I think there is a middle ground where you avoid errors that you don't want (allowing `nil` to be passed as method arguments in many cases, for example), but still raise errors on other things.

The code in this PR is just an adaption of what I had already done to create a proof-of-concept JRuby implementation. It's basically done, but the work that is missing is merging the two implementations.

This is not going to be easy. The code is already written, that part is no problem, the hard part is making sure that it works and it feels like one gem. I've written most of the JRuby implementation of [msgpack-ruby](https://github.com/msgpack/msgpack-ruby), and maintaining that gem is problematic. There will be pull requests that add features only to one of the implementations, and you'll get bug reports where it's unclear which implementation was used (because people don't care about that, and they shouldn't have to). Getting the parsers to work the same, getting errors to work the same and being raised for the same expressions at the same time (compile time vs. runtime, for example) will be a pain.

Don't accept this PR lightly, and if you do I will need to have commit rights to the main repo, and also rights to release the gem, otherwise it's not going to work.
