### PR TITLE
Fix indentation warning

### DIFF
--- a/lib/jmespath/nodes/function.rb
+++ b/lib/jmespath/nodes/function.rb
@@ -207,7 +207,7 @@ module JMESPath
           return maybe_raise Errors::InvalidTypeError, "function map() expects the second argument to be an list"
         end
         list.map { |value| expr.eval(value) }
-    end
+      end
 
     end
 


### PR DESCRIPTION
Previously when running with verbose mode a warning was generated every time it hit the function file because

```
/Users/kdeisz/Documents/projects/jmespath.rb/lib/jmespath/nodes/function.rb:210: warning: mismatched indentations at 'end' with 'def' at 195
```