### PR TITLE
Fix typo of a license name in gemspec

### DIFF
--- a/jmespath.gemspec
+++ b/jmespath.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.author        = 'Trevor Rowe'
   spec.email         = 'trevorrowe@gmail.com'
   spec.homepage      = 'http://github.com/trevorrowe/jmespath.rb'
-  spec.license       = 'Apache 2.0'
+  spec.license       = 'Apache-2.0'
   spec.require_paths = ['lib']
   spec.files         = Dir['lib/**/*.rb'] + ['LICENSE.txt']
 end


### PR DESCRIPTION
`rake gem:build` warns about license name.

```bash
$ bundle exec rake gem:build
gem build jmespath.gemspec
WARNING:  license value 'Apache 2.0' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'Apache-2.0'?
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: jmespath
  Version: 1.3.1
  File: jmespath-1.3.1.gem
```

This change fixes the warning.