### PR TITLE
add support for floating point comparisons

### DIFF
--- a/lib/jmespath/nodes/comparator.rb
+++ b/lib/jmespath/nodes/comparator.rb
@@ -54,25 +54,25 @@ module JMESPath
 
       class Gt < Comparator
         def check(left_value, right_value)
-          left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value > right_value
+          left_value.is_a?(Numeric) && right_value.is_a?(Numeric) && left_value > right_value
         end
       end
 
       class Gte < Comparator
         def check(left_value, right_value)
-          left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value >= right_value
+          left_value.is_a?(Numeric) && right_value.is_a?(Numeric) && left_value >= right_value
         end
       end
 
       class Lt < Comparator
         def check(left_value, right_value)
-          left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value < right_value
+          left_value.is_a?(Numeric) && right_value.is_a?(Numeric) && left_value < right_value
         end
       end
 
       class Lte < Comparator
         def check(left_value, right_value)
-          left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value <= right_value
+          left_value.is_a?(Numeric) && right_value.is_a?(Numeric) && left_value <= right_value
         end
       end
     end

--- a/spec/compliance/boolean.json
+++ b/spec/compliance/boolean.json
@@ -205,7 +205,9 @@
     "given": {
       "one": 1,
       "two": 2,
-      "three": 3
+      "three": 3,
+      "one_dot_zero": 1.0,
+      "two_dot_zero": 2.0
     },
     "cases": [
       {
@@ -251,6 +253,34 @@
       {
         "expression": "two < one || three < one",
         "result": false
+      },
+      {
+        "expression": "one_dot_zero < two_dot_zero",
+        "result": true
+      },
+      {
+        "expression": "two_dot_zero > one_dot_zero",
+        "result": true
+      },
+      {
+        "expression": "one_dot_zero <= one_dot_zero",
+        "result": true
+      },
+      {
+        "expression": "one_dot_zero >= one_dot_zero",
+        "result": true
+      },
+      {
+        "expression": "one_dot_zero == two_dot_zero",
+        "result": false
+      },
+      {
+        "expression": "one_dot_zero != two_dot_zero",
+        "result": true
+      },
+      {
+        "expression": "one_dot_zero == one_dot_zero",
+        "result": true
       }
     ]
   }

--- a/spec/jmespath_spec.rb
+++ b/spec/jmespath_spec.rb
@@ -34,5 +34,24 @@ module JMESPath
       expect(JMESPath.search('`1` < `2`', {})).to be(true)
     end
 
+    context 'boolean comparison' do
+      it 'supports floating point numbers' do
+        expect(JMESPath.search('`1.0` == `1.0`', {})).to be true
+        expect(JMESPath.search('`2.0` != `1.0`', {})).to be true
+        expect(JMESPath.search('`2.0` > `1.0`', {})).to be true
+        expect(JMESPath.search('`1.0` < `2.0`', {})).to be true
+        expect(JMESPath.search('`2.0` >= `1.0`', {})).to be true
+        expect(JMESPath.search('`1.0` <= `2.0`', {})).to be true
+        expect(JMESPath.search('`1.0` <= `1.0`', {})).to be true
+        expect(JMESPath.search('`1.0` >= `1.0`', {})).to be true
+
+        expect(JMESPath.search('`2.0` == `1.0`', {})).to be false
+        expect(JMESPath.search('`1.0` != `1.0`', {})).to be false
+        expect(JMESPath.search('`1.0` > `1.0`', {})).to be false
+        expect(JMESPath.search('`2.0` < `2.0`', {})).to be false
+        expect(JMESPath.search('`1.0` >= `2.0`', {})).to be false
+        expect(JMESPath.search('`2.0` <= `1.0`', {})).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
I ran across this and discovered only integers were supported in comparisons. The specification supports floating point numbers. Simply expand the scope to the `Numeric` class to validate any number that is comparable.