### PR TITLE
Update Gitter badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jmespath.rb
 
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/trevorrowe/jmespath.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/jmespath/jmespath.rb.png?branch=master)](https://travis-ci.org/jmespath/jmespath.rb)
+[![Gitter chat](https://badges.gitter.im/jmespath/jmespath.rb.png)](https://gitter.im/jmespath/jmespath.rb) [![Build Status](https://travis-ci.org/jmespath/jmespath.rb.png?branch=master)](https://travis-ci.org/jmespath/jmespath.rb)
 
 An implementation of [JMESPath](https://github.com/boto/jmespath) for Ruby. This implementation supports searching JSON documents as well as native Ruby data structures.
 


### PR DESCRIPTION
The existing gitter badge still contains trevorrowe as the owner. This is no longer correct now that the repo is under the jmespath organization. This commit updates the gitter.im badge to reflect the change.