### PR TITLE
Update gemspec so bin wrapper is created in PATH

### DIFF
--- a/jmespath.gemspec
+++ b/jmespath.gemspec
@@ -8,5 +8,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/trevorrowe/jmespath.rb'
   spec.license       = 'Apache-2.0'
   spec.require_paths = ['lib']
+  spec.executables   = Dir['bin/**'].map &File.method(:basename)
   spec.files         = Dir['lib/**/*.rb'] + ['LICENSE.txt']
 end


### PR DESCRIPTION
I just installed this gem and I ran into a minor annoyance: `jmespath.rb` isn't added to `$GEM_HOME/bin` automatically, and therefore it's not possible to easily run `bin/jmespath.rb` from the command line. 

The cause of this is that `jmespath.rb` was not listed in the gemspec in the `executables` field. 

This one-line PR defines that field in the gemspec and fixes this problem.