### PR TITLE
Allow string comparison

### DIFF
--- a/lib/jmespath/nodes/comparator.rb
+++ b/lib/jmespath/nodes/comparator.rb
@@ -2,6 +2,8 @@ module JMESPath
   # @api private
   module Nodes
     class Comparator < Node
+      COMPARABLE_TYPES = [Numeric, String].freeze
+
       attr_reader :left, :right
 
       def initialize(left, right)
@@ -36,6 +38,12 @@ module JMESPath
       def check(left_value, right_value)
         nil
       end
+
+      def comparable?(left_value, right_value)
+        COMPARABLE_TYPES.any? do |type|
+          left_value.is_a?(type) && right_value.is_a?(type)
+        end
+      end
     end
 
     module Comparators
@@ -54,7 +62,7 @@ module JMESPath
 
       class Gt < Comparator
         def check(left_value, right_value)
-          if left_value.is_a?(Numeric) && right_value.is_a?(Numeric)
+          if comparable?(left_value, right_value)
             left_value > right_value
           else
             nil
@@ -64,7 +72,7 @@ module JMESPath
 
       class Gte < Comparator
         def check(left_value, right_value)
-          if left_value.is_a?(Numeric) && right_value.is_a?(Numeric)
+          if comparable?(left_value, right_value)
             left_value >= right_value
           else
             nil
@@ -74,7 +82,7 @@ module JMESPath
 
       class Lt < Comparator
         def check(left_value, right_value)
-          if left_value.is_a?(Numeric) && right_value.is_a?(Numeric)
+          if comparable?(left_value, right_value)
             left_value < right_value
           else
             nil
@@ -84,7 +92,7 @@ module JMESPath
 
       class Lte < Comparator
         def check(left_value, right_value)
-          if left_value.is_a?(Numeric) && right_value.is_a?(Numeric)
+          if comparable?(left_value, right_value)
             left_value <= right_value
           else
             nil

--- a/lib/jmespath/nodes/condition.rb
+++ b/lib/jmespath/nodes/condition.rb
@@ -27,6 +27,7 @@ module JMESPath
 
     class ComparatorCondition < Node
       COMPARATOR_TO_CONDITION = {}
+      COMPARABLE_TYPES = [Integer, String].freeze
 
       def initialize(left, right, child)
         @left = left
@@ -36,6 +37,14 @@ module JMESPath
 
       def visit(value)
         nil
+      end
+
+      private
+
+      def comparable?(left_value, right_value)
+        COMPARABLE_TYPES.any? do |type|
+          left_value.is_a?(type) && right_value.is_a?(type)
+        end
       end
     end
 
@@ -99,7 +108,7 @@ module JMESPath
       def visit(value)
         left_value = @left.visit(value)
         right_value = @right.visit(value)
-        left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value > right_value ? @child.visit(value) : nil
+        comparable?(left_value, right_value) && left_value > right_value ? @child.visit(value) : nil
       end
     end
 
@@ -109,7 +118,7 @@ module JMESPath
       def visit(value)
         left_value = @left.visit(value)
         right_value = @right.visit(value)
-        left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value >= right_value ? @child.visit(value) : nil
+        comparable?(left_value, right_value) && left_value >= right_value ? @child.visit(value) : nil
       end
     end
 
@@ -119,7 +128,7 @@ module JMESPath
       def visit(value)
         left_value = @left.visit(value)
         right_value = @right.visit(value)
-        left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value < right_value ? @child.visit(value) : nil
+        comparable?(left_value, right_value) && left_value < right_value ? @child.visit(value) : nil
       end
     end
 
@@ -129,7 +138,7 @@ module JMESPath
       def visit(value)
         left_value = @left.visit(value)
         right_value = @right.visit(value)
-        left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value <= right_value ? @child.visit(value) : nil
+        comparable?(left_value, right_value) && left_value <= right_value ? @child.visit(value) : nil
       end
     end
   end

--- a/spec/compliance/boolean.json
+++ b/spec/compliance/boolean.json
@@ -286,6 +286,14 @@
       {
         "expression": "two < one || three < one",
         "result": false
+      },
+      {
+        "expression": "'2010-02-01' > '2011-05-01'",
+        "result": false
+      },
+      {
+        "expression": "'2010-02-01' <= '2011-05-01'",
+        "result": true
       }
     ]
   }

--- a/spec/compliance/filters.json
+++ b/spec/compliance/filters.json
@@ -464,5 +464,29 @@
         "result": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
       }
     ]
+  },
+  {
+    "given": {
+      "foo": ["2010-02-01", "2011-05-01"]
+    },
+    "cases": [
+      {
+        "comment": "Greater than with ISO 8601 date string",
+        "expression": "foo[?@ > '2010-06-01']",
+        "result": ["2011-05-01"]
+      }
+    ]
+  },
+  {
+    "given": {
+      "foo": [{"date": "2010-02-01"}, {"date": "2011-05-01"}]
+    },
+    "cases": [
+      {
+        "comment": "Greater than with ISO 8601 date string",
+        "expression": "foo[?date > '2010-06-01'].date",
+        "result": ["2011-05-01"]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This library currently only supports "comparison" of numberic values.  This appears to match the JMESPath spec but is not consistent with other implementations (for example: [`jmespath.py`](https://github.com/jmespath/jmespath.py/pull/126)).

Resolves: https://github.com/jmespath/jmespath.rb/issues/47