### PR TITLE
duck-type values responding to #to_hash or #to_ary

### DIFF
--- a/lib/jmespath/nodes.rb
+++ b/lib/jmespath/nodes.rb
@@ -5,10 +5,6 @@ module JMESPath
       def visit(value)
       end
 
-      def hash_like?(value)
-        Hash === value || Struct === value
-      end
-
       def optimize
         self
       end

--- a/lib/jmespath/nodes/comparator.rb
+++ b/lib/jmespath/nodes/comparator.rb
@@ -42,13 +42,13 @@ module JMESPath
 
       class Eq < Comparator
         def check(left_value, right_value)
-          left_value == right_value
+          Util.as_json(left_value) == Util.as_json(right_value)
         end
       end
 
       class Neq < Comparator
         def check(left_value, right_value)
-          left_value != right_value
+          Util.as_json(left_value) != Util.as_json(right_value)
         end
       end
 

--- a/lib/jmespath/nodes/condition.rb
+++ b/lib/jmespath/nodes/condition.rb
@@ -43,7 +43,7 @@ module JMESPath
       COMPARATOR_TO_CONDITION[Comparators::Eq] = self
 
       def visit(value)
-        @left.visit(value) == @right.visit(value) ? @child.visit(value) : nil
+        Util.as_json(@left.visit(value)) == Util.as_json(@right.visit(value)) ? @child.visit(value) : nil
       end
 
       def optimize
@@ -62,7 +62,7 @@ module JMESPath
       end
 
       def visit(value)
-        @left.visit(value) == @right ? @child.visit(value) : nil
+        Util.as_json(@left.visit(value)) == @right ? @child.visit(value) : nil
       end
     end
 
@@ -70,7 +70,7 @@ module JMESPath
       COMPARATOR_TO_CONDITION[Comparators::Neq] = self
 
       def visit(value)
-        @left.visit(value) != @right.visit(value) ? @child.visit(value) : nil
+        Util.as_json(@left.visit(value)) != Util.as_json(@right.visit(value)) ? @child.visit(value) : nil
       end
 
       def optimize
@@ -89,7 +89,7 @@ module JMESPath
       end
 
       def visit(value)
-        @left.visit(value) != @right ? @child.visit(value) : nil
+        Util.as_json(@left.visit(value)) != @right ? @child.visit(value) : nil
       end
     end
 

--- a/lib/jmespath/nodes/field.rb
+++ b/lib/jmespath/nodes/field.rb
@@ -8,9 +8,10 @@ module JMESPath
       end
 
       def visit(value)
-        if value.is_a?(Array) && @key.is_a?(Integer)
-          value[@key]
-        elsif value.is_a?(Hash)
+        if value.respond_to?(:to_ary) && @key.is_a?(Integer)
+          value.to_ary[@key]
+        elsif value.respond_to?(:to_hash)
+          value = value.to_hash
           if !(v = value[@key]).nil?
             v
           elsif @key_sym && !(v = value[@key_sym]).nil?
@@ -48,9 +49,10 @@ module JMESPath
 
       def visit(obj)
         @keys.reduce(obj) do |value, key|
-          if value.is_a?(Array) && key.is_a?(Integer)
-            value[key]
-          elsif value.is_a?(Hash)
+          if value.respond_to?(:to_ary) && key.is_a?(Integer)
+            value.to_ary[key]
+          elsif value.respond_to?(:to_hash)
+            value = value.to_hash
             if !(v = value[key]).nil?
               v
             elsif (sym = @key_syms[key]) && !(v = value[sym]).nil?

--- a/lib/jmespath/nodes/flatten.rb
+++ b/lib/jmespath/nodes/flatten.rb
@@ -8,10 +8,10 @@ module JMESPath
 
       def visit(value)
         value = @child.visit(value)
-        if Array === value
-          value.each_with_object([]) do |v, values|
-            if Array === v
-              values.concat(v)
+        if value.respond_to?(:to_ary)
+          value.to_ary.each_with_object([]) do |v, values|
+            if v.respond_to?(:to_ary)
+              values.concat(v.to_ary)
             else
               values.push(v)
             end

--- a/lib/jmespath/nodes/function.rb
+++ b/lib/jmespath/nodes/function.rb
@@ -151,11 +151,11 @@ module JMESPath
       def call(args)
         if args.count == 2
           haystack = args[0]
-          needle = args[1]
+          needle = Util.as_json(args[1])
           if haystack.respond_to?(:to_str)
             haystack.to_str.include?(needle)
           elsif haystack.respond_to?(:to_ary)
-            haystack.to_ary.include?(needle)
+            haystack.to_ary.any? { |e| Util.as_json(e) == needle }
           else
             return maybe_raise Errors::InvalidTypeError, "contains expects 2nd arg to be a list"
           end

--- a/lib/jmespath/nodes/projection.rb
+++ b/lib/jmespath/nodes/projection.rb
@@ -45,8 +45,8 @@ module JMESPath
 
     class ArrayProjection < Projection
       def extract_targets(target)
-        if Array === target
-          target
+        if target.respond_to?(:to_ary)
+          target.to_ary
         else
           nil
         end
@@ -63,7 +63,9 @@ module JMESPath
 
     class ObjectProjection < Projection
       def extract_targets(target)
-        if hash_like?(target)
+        if target.respond_to?(:to_hash)
+          target.to_hash.values
+        elsif target.is_a?(Struct)
           target.values
         else
           nil

--- a/lib/jmespath/nodes/slice.rb
+++ b/lib/jmespath/nodes/slice.rb
@@ -10,7 +10,7 @@ module JMESPath
       end
 
       def visit(value)
-        if String === value || Array === value
+        if (value = value.respond_to?(:to_str) ? value.to_str : value.respond_to?(:to_ary) ? value.to_ary : nil)
           start, stop, step = adjust_slice(value.size, @start, @stop, @step)
           result = []
           if step > 0
@@ -26,7 +26,7 @@ module JMESPath
               i += step
             end
           end
-          String === value ? result.join : result
+          value.respond_to?(:to_str) ? result.join : result
         else
           nil
         end
@@ -80,7 +80,7 @@ module JMESPath
       end
 
       def visit(value)
-        if String === value || Array === value
+        if (value = value.respond_to?(:to_str) ? value.to_str : value.respond_to?(:to_ary) ? value.to_ary : nil)
           value[@start, @stop - @start]
         else
           nil

--- a/lib/jmespath/util.rb
+++ b/lib/jmespath/util.rb
@@ -9,7 +9,9 @@ module JMESPath
       #
       def falsey?(value)
         !value ||
-        (value.respond_to?(:empty?) && value.empty?) ||
+        (value.respond_to?(:to_ary) && value.to_ary.empty?) ||
+        (value.respond_to?(:to_hash) && value.to_hash.empty?) ||
+        (value.respond_to?(:to_str) && value.to_str.empty?) ||
         (value.respond_to?(:entries) && !value.entries.any?)
         # final case necessary to support Enumerable and Struct
       end

--- a/lib/jmespath/util.rb
+++ b/lib/jmespath/util.rb
@@ -15,6 +15,20 @@ module JMESPath
         (value.respond_to?(:entries) && !value.entries.any?)
         # final case necessary to support Enumerable and Struct
       end
+
+      def as_json(value)
+        if value.respond_to?(:to_ary)
+          value.to_ary.map { |e| as_json(e) }
+        elsif value.respond_to?(:to_hash)
+          hash = {}
+          value.to_hash.each_pair { |k, v| hash[k] = as_json(v) }
+          hash
+        elsif value.respond_to?(:to_str)
+          value.to_str
+        else
+          value
+        end
+      end
     end
   end
 end

--- a/spec/compliance/boolean.json
+++ b/spec/compliance/boolean.json
@@ -207,6 +207,7 @@
       "two": 2,
       "three": 3,
       "emptylist": [],
+      "complexlist": [{}, []],
       "boolvalue": false
     },
     "cases": [
@@ -220,6 +221,22 @@
       },
       {
         "expression": "one == one",
+        "result": true
+      },
+      {
+        "expression": "emptylist == `[]`",
+        "result": true
+      },
+      {
+        "expression": "emptylist == emptylist",
+        "result": true
+      },
+      {
+        "expression": "complexlist == `[{}, []]`",
+        "result": true
+      },
+      {
+        "expression": "complexlist == complexlist",
         "result": true
       },
       {

--- a/spec/compliance/functions.json
+++ b/spec/compliance/functions.json
@@ -4,7 +4,7 @@
     "foo": -1,
     "zero": 0,
     "numbers": [-1, 3, 4, 5],
-    "array": [-1, 3, 4, 5, "a", "100"],
+    "array": [-1, 3, 4, 5, "a", "100", [{}]],
     "strings": ["a", "b", "c"],
     "decimals": [1.01, 1.2, -1.5],
     "str": "Str",
@@ -132,6 +132,10 @@
       "result": false
     },
     {
+      "expression": "contains(array, `[{}]`)",
+      "result": true
+    },
+    {
       "expression": "ends_with(str, 'r')",
       "result": true
     },
@@ -201,7 +205,7 @@
     },
     {
       "expression": "length(array)",
-      "result": 6
+      "result": 7
     },
     {
       "expression": "length(objects)",
@@ -405,7 +409,7 @@
     },
     {
       "expression": "reverse(array)",
-      "result": ["100", "a", 5, 4, 3, -1]
+      "result": [[{}], "100", "a", 5, 4, 3, -1]
     },
     {
       "expression": "reverse(`[]`)",

--- a/spec/implicit_conversion_spec.rb
+++ b/spec/implicit_conversion_spec.rb
@@ -54,5 +54,33 @@ module JMESPath
       end
 
     end
+
+    describe 'Compliance' do
+      Dir.glob('spec/{compliance,legacy}/*.json').each do |path|
+
+        test_file = File.basename(path).split('.').first
+        next if test_file == 'benchmarks'
+        next if ENV['TEST_FILE'] && ENV['TEST_FILE'] != test_file
+
+        describe(test_file) do
+          JMESPath.load_json(path).each do |scenario|
+            describe("Given #{scenario['given'].to_json}") do
+              scenario['cases'].each do |test_case|
+
+                if !test_case['error']
+                  it "searching #{test_case['expression'].inspect} returns #{test_case['result'].to_json}" do
+                    result = JMESPath.search(test_case['expression'], Wrapper.wrap(scenario['given']))
+
+                    expect(JMESPath::Util.as_json(result)).to eq(test_case['result'])
+                  end
+
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
   end
 end

--- a/spec/implicit_conversion_spec.rb
+++ b/spec/implicit_conversion_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+module Wrapper
+  def self.wrap(o)
+    o.respond_to?(:to_ary) ? Arrayish.new(o) : o.respond_to?(:to_hash) ? Hashish.new(o) : o
+  end
+end
+
+class Arrayish
+  def initialize(ary)
+    @ary = ary.to_ary
+  end
+
+  attr_reader :ary
+
+  def to_ary
+    @ary.map { |e| Wrapper.wrap(e) }
+  end
+end
+
+class Hashish
+  def initialize(hash)
+    @hash = hash.to_hash
+  end
+
+  attr_reader :hash
+
+  def to_hash
+    to_hash = {}
+    @hash.each_pair { |k, v| to_hash[k] = Wrapper.wrap(v) }
+    to_hash
+  end
+end
+
+module JMESPath
+  describe '.search' do
+    describe 'implicit conversion' do
+
+      it 'searches hash/array structures' do
+        data = Hashish.new({'foo' => {'bar' => ['value']}})
+        result = JMESPath.search('foo.bar', data)
+        expect(result).to be_instance_of(Arrayish)
+        expect(result.ary).to eq(['value'])
+      end
+
+      it 'searches with flatten' do
+        data = Hashish.new({'foo' => [[{'bar' => 0}], [{'baz' => 0}]]})
+        result = JMESPath.search('foo[]', data)
+        expect(result.size).to eq(2)
+        expect(result[0]).to be_instance_of(Hashish)
+        expect(result[0].hash).to eq({'bar' => 0})
+        expect(result[1]).to be_instance_of(Hashish)
+        expect(result[1].hash).to eq({'baz' => 0})
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
I work with JSON data wrapped in classes which behave like Hash and Array, which respond to #to_hash / #to_ary to support implicit conversion (as described in https://docs.ruby-lang.org/en/master/doc/implicit_conversion_rdoc.html )

this PR lets jmespath be used with these implicitly convertible objects. it is in draft because I have updated no tests or documentation, and may be incomplete in other ways. if an active maintainer can tell me it might be merged, I will bring it to completion. 